### PR TITLE
1 morrowind bag space

### DIFF
--- a/MassDeconstructor.lua
+++ b/MassDeconstructor.lua
@@ -115,7 +115,6 @@ function MD.addStuffToInventoryForBag(bagId)
   local bagSize = GetBagSize(bagId)
   local usableBagSize = GetBagUseableSize(bagId)
   local bagSlots = GetBagSize(bagId) -1
-  if bagId == BAG_SUBSCRIBER_BANK then bagSlots = 479 end
   if MD.isDebug then
     d("bagID: |cdddddd"..(bagId).."|r bagSlots: |cdddddd"..(usableBagSize).."/"..(bagSize).."|r")
   end
@@ -351,13 +350,12 @@ function MD.updateStuffofInventory()
   }
 
   MD.addStuffToInventoryForBag(BAG_BACKPACK)
-  -- bank
-  if IsESOPlusSubscriber() then
-    if MD.isDebug then d("Subscriber") end
-    if MD.settings.BankMode then MD.addStuffToInventoryForBag(BAG_SUBSCRIBER_BANK) end
-  else
-    if MD.isDebug then d("Non-subscriber") end
-    if MD.settings.BankMode then MD.addStuffToInventoryForBag(BAG_BANK) end
+  if MD.settings.BankMode then 
+    -- add stuff from bank
+    -- subscribers get extra bank space
+    if IsESOPlusSubscriber() then MD.addStuffToInventoryForBag(BAG_SUBSCRIBER_BANK) end
+    -- regular bank
+    MD.addStuffToInventoryForBag(BAG_BANK)
   end
 
 end

--- a/MassDeconstructor.lua
+++ b/MassDeconstructor.lua
@@ -21,6 +21,7 @@ MD.defaults = {
   DeconstructOrnate = false,
   DeconstructBound = false,
   DeconstructSetPiece = false,
+  Debug = false,
   BankMode = false,
   Clothing = {
     maxQuality = 4,
@@ -111,7 +112,13 @@ function MD.addStuffToInventoryForBag(bagId)
   local GetItemInfo = GetItemInfo
   local zo_strformat = zo_strformat
   local GetItemName = GetItemName
+  local bagSize = GetBagSize(bagId)
+  local usableBagSize = GetBagUseableSize(bagId)
   local bagSlots = GetBagSize(bagId) -1
+  if bagId == BAG_SUBSCRIBER_BANK then bagSlots = 479 end
+  if MD.isDebug then
+    d("bagID: |cdddddd"..(bagId).."|r bagSlots: |cdddddd"..(usableBagSize).."/"..(bagSize).."|r")
+  end
   for slotIndex = 0, bagSlots do
     local itemType = GetItemType(bagId, slotIndex)
     local _, stack, _, _, _, equipType , _, quality = GetItemInfo(bagId, slotIndex)
@@ -345,12 +352,19 @@ function MD.updateStuffofInventory()
 
   MD.addStuffToInventoryForBag(BAG_BACKPACK)
   -- bank
-  if MD.settings.BankMode then MD.addStuffToInventoryForBag(BAG_BANK) end
+  if IsESOPlusSubscriber() then
+    if MD.isDebug then d("Subscriber") end
+    if MD.settings.BankMode then MD.addStuffToInventoryForBag(BAG_SUBSCRIBER_BANK) end
+  else
+    if MD.isDebug then d("Non-subscriber") end
+    if MD.settings.BankMode then MD.addStuffToInventoryForBag(BAG_BANK) end
+  end
 
 end
 
 function MD:OnCrafting(sameStation)
   MD.updateStuffofInventory() 
+  MD.isDebug = MD.settings.Debug
   if MD.isDebug then
     if MD.isStation == 1 then
       d("MD Clothier")

--- a/MassDeconstructor.txt
+++ b/MassDeconstructor.txt
@@ -1,7 +1,7 @@
 ## Title: Mass Deconstructor
-## Description: This addon massly deconstruct all your item filtered by your conditions
-## APIVersion: 100011
-## Author: AhmetAmadErtem
+## Description: This addon mass deconstructs all items determined by your configured conditions
+## APIVersion: 100019
+## Author: MaraRinn
 ## Version: 1.0
 ## DependsOn:
 ## OptionalDependsOn: LibAddonMenu-2.0

--- a/MassDeconstructorMenu.lua
+++ b/MassDeconstructorMenu.lua
@@ -45,6 +45,12 @@ function MD.MakeMenu()
       setFunc = function(value) set.DeconstructOrnate = value end,
     },
     {
+      type = "checkbox",
+      name = "Debug",
+      getFunc = function() return set.Debug end,
+      setFunc = function(value) set.Debug = value end,
+    },
+    {
       type = "submenu",
       name = "Clothing Options",
       controls = {

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ Mass Deconstructor is a deconstructing & refining tool to help you clear your ba
 Use the AddOn Settings to configure the types of items to automatically deconstruct. Please be careful about allowing Mass Deconstructor to deconstruct "set items" with high quality.
 
 **This addon is not functional, I'm still learning how to write ESO AddOns**
+
+# History
+
+Originally written by ahmetertem as [Mass Deconstructor](http://www.esoui.com/downloads/info1118-MassDeconstructor.html), it stopped working with the Morrowind release.
+
+MaralieRindu has taken up maintenance of the package under the name "Mass Deconstructor (Revived)". This release marks restoration of the basic functionality, with mass refining of raw materials coming soon. Follow along at the [GitHub repository](https://github.com/MaraRinn/ESO-MassDeconstructor) for issues and development.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Mass Deconstructor is a deconstructing & refining tool to help you clear your ba
 
 Use the AddOn Settings to configure the types of items to automatically deconstruct. Please be careful about allowing Mass Deconstructor to deconstruct "set items" with high quality.
 
-**This addon is not functional, I'm still learning how to write ESO AddOns**
-
 # History
 
 Originally written by ahmetertem as [Mass Deconstructor](http://www.esoui.com/downloads/info1118-MassDeconstructor.html), it stopped working with the Morrowind release.


### PR DESCRIPTION
Fixes #1 

The ESO Plus subscriber bank is a separate "bag" to the main bank, so we have to inspect it separately if the user is a subscriber.