### PR TITLE
15 leave crafted items alone

### DIFF
--- a/MassDeconstructor.lua
+++ b/MassDeconstructor.lua
@@ -12,6 +12,7 @@ MD.defaults = {
   DeconstructOrnate = false,
   DeconstructBound = false,
   DeconstructSetPiece = false,
+  DeconstructCrafted = false,
   Debug = false,
   BankMode = false,
   Verbose = false,
@@ -167,6 +168,10 @@ local function ShouldDeconstructItem(bagId, slotIndex, itemLink)
   end
 
   if isSetPc and not MD.settings.DeconstructSetPiece then
+    return false
+  end
+
+  if IsItemLinkCrafted(itemLink) and not MD.settings.DeconstructCrafted then
     return false
   end
   

--- a/MassDeconstructor.lua
+++ b/MassDeconstructor.lua
@@ -238,10 +238,11 @@ end
 
 local function ListItemsInQueue()
   itemString = #MD.deconstructQueue == 1 and 'item' or 'items'
-  d('Mass Deconstruct will destroy ' .. #MD.deconstructQueue .. ' ' .. itemString ..':')
+  d('Mass Deconstruct will destroy:')
   for index, thing in ipairs(MD.deconstructQueue) do
     d(' - ' .. thing.itemLink)
   end
+  d(#MD.deconstructQueue .. ' ' .. itemString)
 end
 
 local function BuildDeconstructionQueue()

--- a/MassDeconstructorMenu.lua
+++ b/MassDeconstructorMenu.lua
@@ -46,6 +46,12 @@ function MD.MakeMenu()
     },
     {
     	type = "checkbox",
+    	name = "Deconstruct crafted items",
+    	getFunc = function() return set.DeconstructCrafted end,
+    	setFunc = function(value) set.DeconstructCrafted = value end,
+    },
+    {
+    	type = "checkbox",
     	name = "List items before starting work",
     	getFunc = function() return set.Verbose end,
     	setFunc = function(value) set.Verbose = value end,


### PR DESCRIPTION
Resolves #15 - MassDeconstructor will now ignore crafted items if you choose that option.